### PR TITLE
Fix wget certificate issue

### DIFF
--- a/part_seg/download_data.sh
+++ b/part_seg/download_data.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Download original ShapeNetPart dataset (around 1GB)
-wget https://shapenet.cs.stanford.edu/ericyi/shapenetcore_partanno_v0.zip
+wget --no-check-certificate https://shapenet.cs.stanford.edu/ericyi/shapenetcore_partanno_v0.zip
 unzip shapenetcore_partanno_v0.zip
 rm shapenetcore_partanno_v0.zip
 
 # Download HDF5 for ShapeNet Part segmentation (around 346MB)
-wget https://shapenet.cs.stanford.edu/media/shapenet_part_seg_hdf5_data.zip
+wget --no-check-certificate https://shapenet.cs.stanford.edu/media/shapenet_part_seg_hdf5_data.zip
 unzip shapenet_part_seg_hdf5_data.zip
 rm shapenet_part_seg_hdf5_data.zip
 

--- a/provider.py
+++ b/provider.py
@@ -12,7 +12,7 @@ if not os.path.exists(DATA_DIR):
 if not os.path.exists(os.path.join(DATA_DIR, 'modelnet40_ply_hdf5_2048')):
     www = 'https://shapenet.cs.stanford.edu/media/modelnet40_ply_hdf5_2048.zip'
     zipfile = os.path.basename(www)
-    os.system('wget %s; unzip %s' % (www, zipfile))
+    os.system('wget --no-check-certificate %s; unzip %s' % (www, zipfile))
     os.system('mv %s %s' % (zipfile[:-4], DATA_DIR))
     os.system('rm %s' % (zipfile))
 


### PR DESCRIPTION
I'm seeing wget download issue due to https certificate. Fix the issue by skipping certificate check.

```
--2018-07-31 22:39:44--  https://shapenet.cs.stanford.edu/media/modelnet40_ply_hdf5_2048.zip
Resolving shapenet.cs.stanford.edu... 171.67.77.19
Connecting to shapenet.cs.stanford.edu|171.67.77.19|:443... connected.
ERROR: cannot verify shapenet.cs.stanford.edu's certificate, issued by ‘CN=InCommon RSA Server CA,OU=InCommon,O=Internet2,L=Ann Arbor,ST=MI,C=US’:
  Issued certificate has expired.
To connect to shapenet.cs.stanford.edu insecurely, use `--no-check-certificate'.
```