### PR TITLE
Fix miscalling function in semantic segmentation test script

### DIFF
--- a/sem_seg/batch_inference.py
+++ b/sem_seg/batch_inference.py
@@ -99,7 +99,7 @@ def eval_one_epoch(sess, ops, room_path, out_data_label_filename, out_gt_label_f
     fout_data_label = open(out_data_label_filename, 'w')
     fout_gt_label = open(out_gt_label_filename, 'w')
     
-    current_data, current_label = indoor3d_util.room2blocks_wrapper_normalized(room_path, NUM_POINT)
+    current_data, current_label = indoor3d_util.room2samples_wrapper_normalized(room_path, NUM_POINT)
     current_data = current_data[:,0:NUM_POINT,:]
     current_label = np.squeeze(current_label)
     # Get room dimension..

--- a/sem_seg/indoor3d_util.py
+++ b/sem_seg/indoor3d_util.py
@@ -285,7 +285,7 @@ def room2samples(data, label, sample_num_point):
 
     batch_num = int(np.ceil(N / float(sample_num_point)))
     sample_datas = np.zeros((batch_num, sample_num_point, 6))
-    sample_labels = np.zeros((batch_num, sample_num_point, 1))
+    sample_labels = np.zeros((batch_num, sample_num_point, 1), dtype=np.uint8)
 
     for i in range(batch_num):
         beg_idx = i*sample_num_point


### PR DESCRIPTION
Hi,

It seems that in the semantic segmentation **testing** script (**_sem_seg/batch_inference.py_**) a miscalling function is used.

The **_room2blocks_wrapper_normalized_** is called to load and format the data before processing it, as in the **training** method. Reminder : basically the function divide the point cloud into blocks and randomly sample points (NUM_POINT) in each block .

As mentioned in the article (5.1, in **Semantic Segmentation in Scenes**)
> At test time, we test on all the points

So, I guess the correct function to call here is **room2samples_wrapper_normalized**, in order to handle all the points.