### PR TITLE
Use --no-check-certificate for wget

### DIFF
--- a/provider.py
+++ b/provider.py
@@ -12,7 +12,7 @@ if not os.path.exists(DATA_DIR):
 if not os.path.exists(os.path.join(DATA_DIR, 'modelnet40_ply_hdf5_2048')):
     www = 'https://shapenet.cs.stanford.edu/media/modelnet40_ply_hdf5_2048.zip'
     zipfile = os.path.basename(www)
-    os.system('wget %s; unzip %s' % (www, zipfile))
+    os.system('wget --no-check-certificate %s; unzip %s' % (www, zipfile))
     os.system('mv %s %s' % (zipfile[:-4], DATA_DIR))
     os.system('rm %s' % (zipfile))
 


### PR DESCRIPTION
Resolves error:
```
ERROR: cannot verify shapenet.cs.stanford.edu's certificate, issued by ‘CN=InCommon RSA Server CA,OU=InCommon,O=Internet2,L=Ann Arbor,ST=MI,C=US’:
  Issued certificate has expired.
To connect to shapenet.cs.stanford.edu insecurely, use `--no-check-certificate'.
```